### PR TITLE
Fix resizeAttackTextToFit function to adjust font size based on both width and height

### DIFF
--- a/app.js
+++ b/app.js
@@ -71,17 +71,18 @@ function App() {
     const resizeAttackTextToFit = () => {
       const attackInfoElements = document.querySelectorAll('.attack-info');
       const maxWidthAttack = 110;
+      const maxHeightAttack = 3 * parseFloat(getComputedStyle(document.documentElement).fontSize); // 3em
 
       attackInfoElements.forEach((attackInfo) => {
         const attackName = attackInfo.querySelector('.attack-name');
         let attackFontSize = parseInt(window.getComputedStyle(attackName).fontSize);
-        if (attackName.scrollWidth > maxWidthAttack) {
-          while (attackName.scrollWidth > maxWidthAttack && attackFontSize > 0) {
+        if (attackName.scrollWidth > maxWidthAttack || attackName.scrollHeight > maxHeightAttack) {
+          while ((attackName.scrollWidth > maxWidthAttack || attackName.scrollHeight > maxHeightAttack) && attackFontSize > 0) {
             attackFontSize--;
             attackName.style.fontSize = attackFontSize + 'px';
           }
         } else {
-          while (attackName.scrollWidth < attackName.clientWidth && attackFontSize < maxWidthAttack) {
+          while (attackName.scrollWidth < attackName.clientWidth && attackName.scrollHeight < maxHeightAttack && attackFontSize < maxWidthAttack) {
             attackFontSize++;
             attackName.style.fontSize = attackFontSize + 'px';
           }
@@ -152,6 +153,11 @@ function App() {
         window.removeEventListener('resize', resizeFactionText);
       };
     }, [factionText]);
+
+    // Effect to resize attack text when attacks state changes
+    React.useEffect(() => {
+      resizeAttackTextToFit();
+    }, [attacks]);
 
     return (
       <div className="container">


### PR DESCRIPTION
Modify the `resizeAttackTextToFit` function in `app.js` to adjust font size based on both width and height.

* Add a `maxHeightAttack` variable to consider the initial max height of the `attack-name` element.
* Update the function to shrink the font size if the text exceeds the max width or height.
* Add a `useEffect` hook to call `resizeAttackTextToFit` when the `attacks` state changes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nebuk89/warhammercardPages?shareId=a1359c3c-d7a5-456a-8c42-e5b15d094c6d).