### PR TITLE
Rename new-field to other-attack-attributes

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,7 +36,7 @@ function App() {
     const updateAttack = (index, field, value) => {
       setAttacks(prev => {
         const newAttacks = [...prev];
-        newAttacks[index] = { ...newAttacks[index], [field]: field === 'name' || field === 'newField' ? value : parseInt(value) };
+        newAttacks[index] = { ...newAttacks[index], [field]: field === 'name' || field === 'otherAttackAttributes' ? value : parseInt(value) };
         return newAttacks;
       });
       if (field === 'name') {
@@ -88,17 +88,17 @@ function App() {
           }
         }
 
-        const newField = attackInfo.querySelector('.new-field');
-        let newFieldFontSize = parseInt(window.getComputedStyle(newField).fontSize);
-        if (newField.scrollWidth > maxWidthAttack / 2) {
-          while (newField.scrollWidth > maxWidthAttack / 2 && newFieldFontSize > 0) {
-            newFieldFontSize--;
-            newField.style.fontSize = newFieldFontSize + 'px';
+        const otherAttackAttributes = attackInfo.querySelector('.other-attack-attributes');
+        let otherAttackAttributesFontSize = parseInt(window.getComputedStyle(otherAttackAttributes).fontSize);
+        if (otherAttackAttributes.scrollWidth > maxWidthAttack / 2) {
+          while (otherAttackAttributes.scrollWidth > maxWidthAttack / 2 && otherAttackAttributesFontSize > 0) {
+            otherAttackAttributesFontSize--;
+            otherAttackAttributes.style.fontSize = otherAttackAttributesFontSize + 'px';
           }
         } else {
-          while (newField.scrollWidth < newField.clientWidth && newFieldFontSize < maxWidthAttack / 2) {
-            newFieldFontSize++;
-            newField.style.fontSize = newFieldFontSize + 'px';
+          while (otherAttackAttributes.scrollWidth < otherAttackAttributes.clientWidth && otherAttackAttributesFontSize < maxWidthAttack / 2) {
+            otherAttackAttributesFontSize++;
+            otherAttackAttributes.style.fontSize = otherAttackAttributesFontSize + 'px';
           }
         }
       });
@@ -212,8 +212,8 @@ function App() {
                     <label>Other stats</label>
                     <input
                       type="text"
-                      value={attack.newField}
-                      onChange={(e) => updateAttack(index, "newField", e.target.value)}
+                      value={attack.otherAttackAttributes}
+                      onChange={(e) => updateAttack(index, "otherAttackAttributes", e.target.value)}
                     />
                   </div>
                 </div>
@@ -266,7 +266,7 @@ function App() {
                         <span className="stat-value">{attack.S}</span>
                         <span className="stat-value">{attack.AP}</span>
                         <span className="stat-value">{attack.D}</span>
-                        <span className="new-field">{attack.newField}</span>
+                        <span className="other-attack-attributes">{attack.otherAttackAttributes}</span>
                       </div>
                     </div>
                   ))}

--- a/app.test.js
+++ b/app.test.js
@@ -60,17 +60,17 @@ describe('App Component', () => {
     const { getByText, getAllByPlaceholderText } = render(<App />);
     const addButton = getByText('Add Attack');
     fireEvent.click(addButton);
-    const newFieldInput = getAllByPlaceholderText('New Field')[0];
-    fireEvent.change(newFieldInput, { target: { value: 'Test New Field' } });
-    expect(newFieldInput.value).toBe('Test New Field');
+    const otherAttackAttributesInput = getAllByPlaceholderText('Other Attack Attributes')[0];
+    fireEvent.change(otherAttackAttributesInput, { target: { value: 'Test Other Attack Attributes' } });
+    expect(otherAttackAttributesInput.value).toBe('Test Other Attack Attributes');
   });
 
   test('should update new text entry state correctly', () => {
     const { getByText, getAllByPlaceholderText } = render(<App />);
     const addButton = getByText('Add Attack');
     fireEvent.click(addButton);
-    const newFieldInput = getAllByPlaceholderText('New Field')[0];
-    fireEvent.change(newFieldInput, { target: { value: 'Test New Field' } });
-    expect(newFieldInput.value).toBe('Test New Field');
+    const otherAttackAttributesInput = getAllByPlaceholderText('Other Attack Attributes')[0];
+    fireEvent.change(otherAttackAttributesInput, { target: { value: 'Test Other Attack Attributes' } });
+    expect(otherAttackAttributesInput.value).toBe('Test Other Attack Attributes');
   });
 });

--- a/style.css
+++ b/style.css
@@ -286,7 +286,7 @@ body {
   white-space: pre-line;
 }
 
-.new-field {
+.other-attack-attributes {
   flex: 0 0 50px;
   font-size: 15px;
   text-align: center;


### PR DESCRIPTION
Rename `new-field` to `other-attack-attributes` and update the `resizeAttackTextToFit` function to apply to `other-attack-attributes`.

* **app.js**
  - Rename all instances of `newField` to `otherAttackAttributes`.
  - Rename all instances of `new-field` to `other-attack-attributes`.
  - Update the `updateAttack` function to use `otherAttackAttributes` instead of `newField`.
  - Update the `resizeAttackTextToFit` function to use `other-attack-attributes` instead of `new-field`.

* **style.css**
  - Rename the CSS class `.new-field` to `.other-attack-attributes`.
  - Update the styles for `.other-attack-attributes` to match the previous `.new-field` styles.

* **app.test.js**
  - Rename all instances of `newField` to `otherAttackAttributes`.
  - Rename all instances of `new-field` to `other-attack-attributes`.
  - Update the test cases to use `otherAttackAttributes` instead of `newField`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nebuk89/warhammercardPages?shareId=f9747f2c-defd-4a37-91d4-710a9fa0b5d5).