### PR TITLE
Ensure other-attack-attributes text resizes on change

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,7 +39,7 @@ function App() {
         newAttacks[index] = { ...newAttacks[index], [field]: field === 'name' || field === 'otherAttackAttributes' ? value : parseInt(value) };
         return newAttacks;
       });
-      if (field === 'name') {
+      if (field === 'name' || field === 'otherAttackAttributes') {
         resizeAttackTextToFit();
       }
     };
@@ -90,13 +90,13 @@ function App() {
 
         const otherAttackAttributes = attackInfo.querySelector('.other-attack-attributes');
         let otherAttackAttributesFontSize = parseInt(window.getComputedStyle(otherAttackAttributes).fontSize);
-        if (otherAttackAttributes.scrollWidth > maxWidthAttack / 2) {
-          while (otherAttackAttributes.scrollWidth > maxWidthAttack / 2 && otherAttackAttributesFontSize > 0) {
+        if (otherAttackAttributes.scrollWidth > maxWidthAttack / 2 || otherAttackAttributes.scrollHeight > maxHeightAttack) {
+          while ((otherAttackAttributes.scrollWidth > maxWidthAttack / 2 || otherAttackAttributes.scrollHeight > maxHeightAttack) && otherAttackAttributesFontSize > 0) {
             otherAttackAttributesFontSize--;
             otherAttackAttributes.style.fontSize = otherAttackAttributesFontSize + 'px';
           }
         } else {
-          while (otherAttackAttributes.scrollWidth < otherAttackAttributes.clientWidth && otherAttackAttributesFontSize < maxWidthAttack / 2) {
+          while (otherAttackAttributes.scrollWidth < otherAttackAttributes.clientWidth && otherAttackAttributes.scrollHeight < maxHeightAttack && otherAttackAttributesFontSize < maxWidthAttack / 2) {
             otherAttackAttributesFontSize++;
             otherAttackAttributes.style.fontSize = otherAttackAttributesFontSize + 'px';
           }

--- a/app.test.js
+++ b/app.test.js
@@ -60,7 +60,7 @@ describe('App Component', () => {
     const { getByText, getAllByPlaceholderText } = render(<App />);
     const addButton = getByText('Add Attack');
     fireEvent.click(addButton);
-    const otherAttackAttributesInput = getAllByPlaceholderText('Other Attack Attributes')[0];
+    const otherAttackAttributesInput = getAllByPlaceholderText('Other stats')[0];
     fireEvent.change(otherAttackAttributesInput, { target: { value: 'Test Other Attack Attributes' } });
     expect(otherAttackAttributesInput.value).toBe('Test Other Attack Attributes');
   });
@@ -69,8 +69,18 @@ describe('App Component', () => {
     const { getByText, getAllByPlaceholderText } = render(<App />);
     const addButton = getByText('Add Attack');
     fireEvent.click(addButton);
-    const otherAttackAttributesInput = getAllByPlaceholderText('Other Attack Attributes')[0];
+    const otherAttackAttributesInput = getAllByPlaceholderText('Other stats')[0];
     fireEvent.change(otherAttackAttributesInput, { target: { value: 'Test Other Attack Attributes' } });
     expect(otherAttackAttributesInput.value).toBe('Test Other Attack Attributes');
+  });
+
+  test('should resize other-attack-attributes text on change', () => {
+    const { getByText, getAllByPlaceholderText } = render(<App />);
+    const addButton = getByText('Add Attack');
+    fireEvent.click(addButton);
+    const otherAttackAttributesInput = getAllByPlaceholderText('Other stats')[0];
+    fireEvent.change(otherAttackAttributesInput, { target: { value: 'Test Other Attack Attributes' } });
+    const otherAttackAttributesElement = document.querySelector('.other-attack-attributes');
+    expect(otherAttackAttributesElement.style.fontSize).not.toBe('');
   });
 });


### PR DESCRIPTION
Update `app.js` to resize `other-attack-attributes` text on change.

* Modify `updateAttack` function to call `resizeAttackTextToFit` when `otherAttackAttributes` field is updated.
* Adjust `resizeAttackTextToFit` function to resize `other-attack-attributes` text on change.
* Update `resizeTextToFit` function to include `other-attack-attributes` in its resizing logic.

* Add test in `app.test.js` to verify `other-attack-attributes` text resizing on change.
* Update existing tests to include `other-attack-attributes` field.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nebuk89/warhammercardPages?shareId=73cf4751-3881-4f47-acdd-b11dee90059b).